### PR TITLE
Fix inconsistency

### DIFF
--- a/mods/cnc-classic/rules/system.yaml
+++ b/mods/cnc-classic/rules/system.yaml
@@ -211,7 +211,7 @@ CRATE:
 		SelectionShares: 5
 		InitialDelay: 15
 		CloakDelay: 125
-		CloakSound: appear1.aud
+		CloakSound: trans1.aud
 		UncloakSound: appear1.aud
 		Effect: cloak
 	GiveMcvCrateAction:

--- a/mods/cnc-classic/rules/vehicles.yaml
+++ b/mods/cnc-classic/rules/vehicles.yaml
@@ -477,7 +477,7 @@ STNK:
 		InitialDelay: 125
 		CloakDelay: 125
 		CloakSound: trans1.aud
-		UncloakSound: trans1.aud
+		UncloakSound: appear1.aud
 	AttackFrontal:
 		PrimaryWeapon: 227mm.stnk
 		PrimaryOffset: 0,-5,0,-3


### PR DESCRIPTION
This fixes system.yaml to have proper sound.

This also changes the stealth tank to use appear1.aud as the uncloak sound, as appear1.aud was used instead of trans1.aud in the DOS version IIRC, so I made a compromise between the two. This also makes it sound better in my opinion.
