### PR TITLE
Fix defences

### DIFF
--- a/mods/cnc-classic/mod.yaml
+++ b/mods/cnc-classic/mod.yaml
@@ -1,6 +1,6 @@
 Metadata:
-	Title: C&C Classic (WIP)
-	Description: Try to emulate the original
+	Title: C&C: TD Classic (WIP)
+	Description: An emulation of the Original Tiberian Dawn
 	Version: {DEV_VERSION}
 	Author: The OpenRA Developers
 

--- a/mods/cnc-classic/rules/defaults.yaml
+++ b/mods/cnc-classic/rules/defaults.yaml
@@ -208,7 +208,7 @@
 		TerrainTypes: Clear,Road
 	SoundOnDamageTransition:
 		DamagedSound: xplos.aud
-		DestroyedSound: xplobig4.aud
+		DestroyedSound: crumble.aud
 	Buildable:
 		Queue: Building
 	GivesBuildableArea:

--- a/mods/cnc-classic/rules/structures.yaml
+++ b/mods/cnc-classic/rules/structures.yaml
@@ -651,7 +651,7 @@ GUN:
 		Queue: Defense
 		BuildPaletteOrder: 40
 		Prerequisites: barracks
-		Owner: gdi,nod
+		Owner: nod
 	Building:
 		Power: -20
 	-GivesBuildableArea:
@@ -730,7 +730,7 @@ GTWR:
 		Queue: Defense
 		BuildPaletteOrder: 50
 		Prerequisites: barracks
-		Owner: gdi,nod
+		Owner: gdi
 	Building:
 		Power: -10
 	-GivesBuildableArea:


### PR DESCRIPTION
This makes the Turret not buildable by GDI, and the Guard tower not buildable by Nod. In the release version this is what occurred. However, in the alpha and beta versions, they were built by both factions (as it is in OpenRA style TD), so this could be interchanged map per map.
