### PR TITLE
Cursor palette cleanup fixes

### DIFF
--- a/OpenRA.Game/Graphics/CursorProvider.cs
+++ b/OpenRA.Game/Graphics/CursorProvider.cs
@@ -42,8 +42,7 @@ namespace OpenRA.Graphics
 			foreach (var s in sequences.NodesDict["Cursors"].Nodes)
 				LoadSequencesForCursor(s.Key, s.Value);
 
-			Palette.ApplyModifiers(new IPaletteModifier[] {});
-			Game.Renderer.SetPalette(Palette);
+			Palette.Initialize();
 		}
 
 		static void LoadSequencesForCursor(string cursorSrc, MiniYaml cursor)
@@ -64,7 +63,7 @@ namespace OpenRA.Graphics
 			var cursorSequence = GetCursorSequence(cursorName);
 			var cursorSprite = cursorSequence.GetSprite(cursorFrame);
 
-			renderer.SpriteRenderer.SetPalette(Palette.texture); //TODO: the build menu flickers you move the mouse
+			renderer.SetPalette(Palette);
 			renderer.SpriteRenderer.DrawSprite(cursorSprite,
 			                                   lastMousePos - cursorSequence.Hotspot,
 			                                   Palette.GetPaletteIndex(cursorSequence.Palette),

--- a/OpenRA.Game/Graphics/HardwarePalette.cs
+++ b/OpenRA.Game/Graphics/HardwarePalette.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Graphics
 		public const int MaxPalettes = 256;
 		int allocated = 0;
 
-		public ITexture texture { get; private set; }
+		public ITexture Texture { get; private set; }
 		Dictionary<string, Palette> palettes;
 		Dictionary<string, int> indices;
 		Dictionary<string, bool> allowsMods;
@@ -32,7 +32,7 @@ namespace OpenRA.Graphics
 			palettes = new Dictionary<string, Palette>();
 			indices = new Dictionary<string, int>();
 			allowsMods = new Dictionary<string, bool>();
-			texture = Game.Renderer.Device.CreateTexture();
+			Texture = Game.Renderer.Device.CreateTexture();
 		}
 
 		public Palette GetPalette(string name)
@@ -78,8 +78,12 @@ namespace OpenRA.Graphics
 					data[j,i] = c[i];
 			}
 
-			// TODO: Doesn't work (why?)
-			texture.SetData(data);
+			Texture.SetData(data);
+		}
+
+		public void Initialize()
+		{
+			ApplyModifiers(new IPaletteModifier[] {});
 		}
 	}
 }

--- a/OpenRA.Game/Graphics/Renderer.cs
+++ b/OpenRA.Game/Graphics/Renderer.cs
@@ -73,11 +73,18 @@ namespace OpenRA.Graphics
 			LineRenderer.SetViewportParams(Resolution, 1f, float2.Zero);
 		}
 
+		ITexture currentPaletteTexture;
 		public void SetPalette(HardwarePalette palette)
 		{
-			RgbaSpriteRenderer.SetPalette(palette.texture);
-			SpriteRenderer.SetPalette(palette.texture);
-			WorldSpriteRenderer.SetPalette(palette.texture);
+			if (palette.Texture == currentPaletteTexture)
+				return;
+
+			Flush();
+			currentPaletteTexture = palette.Texture;
+
+			RgbaSpriteRenderer.SetPalette(currentPaletteTexture);
+			SpriteRenderer.SetPalette(currentPaletteTexture);
+			WorldSpriteRenderer.SetPalette(currentPaletteTexture);
 		}
 
 		public void EndFrame(IInputHandler inputHandler)

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -47,9 +47,7 @@ namespace OpenRA.Graphics
 			foreach (var pal in world.traitDict.ActorsWithTraitMultiple<IPalette>(world))
 				pal.Trait.InitPalette(this);
 
-			// Generate initial palette texture
-			palette.ApplyModifiers(new IPaletteModifier[] {});
-			Game.Renderer.SetPalette(palette);
+			palette.Initialize();
 
 			terrainRenderer = new TerrainRenderer(world, this);
 			shroudRenderer = new ShroudRenderer(world);


### PR DESCRIPTION
There were two minor problems (easy to miss) - you were calling the SpriteRenderer SetPalette instead of the Renderer SetPalette, and you need to flush the renderer on palette change. I made a couple of further improvements while I was there.

I recommend you squash this into your previous patch to avoid unnecessary noise.
