### PR TITLE
Polish the Exodus mission

### DIFF
--- a/mods/ra/maps/exodus/exodus.lua
+++ b/mods/ra/maps/exodus/exodus.lua
@@ -115,11 +115,9 @@ SpawnAlliedUnit = function(units)
 	end
 
 	Utils.Do(humans, function(player)
-		if player and player.IsLocalPlayer then
-			Trigger.AfterDelay(DateTime.Seconds(2), function()
-				Media.PlaySpeechNotification(player, "AlliedReinforcementsNorth")
-			end)
-		end
+		Trigger.AfterDelay(DateTime.Seconds(2), function()
+			Media.PlaySpeechNotification(player, "AlliedReinforcementsNorth")
+		end)
 	end)
 
 	if CurrentReinforcement1 < #Reinforcements1 then

--- a/mods/ra/maps/exodus/exodus.lua
+++ b/mods/ra/maps/exodus/exodus.lua
@@ -299,7 +299,7 @@ Tick = function()
 
 		Utils.Do(humans, function(player)
 			if player and player.HasNoRequiredUnits() then
-				soviets.MarkCompletedObjective(sovietObjective)
+				player.MarkFailedObjective(evacuateUnits)
 			end
 		end)
 	end

--- a/mods/ra/maps/exodus/exodus.lua
+++ b/mods/ra/maps/exodus/exodus.lua
@@ -141,21 +141,19 @@ end
 
 SovietGroupSize = 5
 SpawnSovietUnits = function()
-	spawnPoint = Utils.Random(SovietEntryPoints)
-	rallyPoint = Utils.Random(SovietRallyPoints)
-	route = { spawnPoint.Location, rallyPoint.Location }
+	local spawnPoint = Utils.Random(SovietEntryPoints)
+	local rallyPoint = Utils.Random(SovietRallyPoints)
+	local route = { spawnPoint.Location, rallyPoint.Location }
 
+	local units = SovietUnits1
 	if DateTime.GameTime >= SovietUnits2Ticks[Difficulty] then
 		units = SovietUnits2
-	else
-		units = SovietUnits1
 	end
 
-	unit = { Utils.Random(units) }
+	local unit = { Utils.Random(units) }
 	Reinforcements.Reinforce(soviets, unit, route)
 
-	delay = math.max(attackAtFrame - 5, minAttackAtFrame)
-
+	local delay = math.max(attackAtFrame - 5, minAttackAtFrame)
 	Trigger.AfterDelay(delay, SpawnSovietUnits)
 end
 

--- a/mods/ra/maps/exodus/rules.yaml
+++ b/mods/ra/maps/exodus/rules.yaml
@@ -1,4 +1,6 @@
 Player:
+	MissionObjectives:
+		GameOverDelay: 10000
 	PlayerResources:
 		DefaultCash: 5000
 

--- a/mods/ra/maps/exodus/rules.yaml
+++ b/mods/ra/maps/exodus/rules.yaml
@@ -1,6 +1,7 @@
 Player:
 	MissionObjectives:
 		GameOverDelay: 10000
+		EarlyGameOver: false
 	PlayerResources:
 		DefaultCash: 5000
 

--- a/mods/ra/maps/exodus/rules.yaml
+++ b/mods/ra/maps/exodus/rules.yaml
@@ -1,3 +1,7 @@
+Player:
+	PlayerResources:
+		DefaultCash: 5000
+
 World:
 	MissionData:
 		Briefing: The Allies are now being flanked from both sides. Evacuate before the remaining Allied forces in the area are wiped out. Einstein has recently developed a technology which allows us to obscure units from the enemy. Pull out at least one prototype mobile gap generator intact.


### PR DESCRIPTION
Let's you drop the https://github.com/OpenRA/OpenRA/pull/11679/commits/7eb6dcc0b3b79c69ee9822cae594e67685f4fc05 commit.

The second last commit extends the GameOverDelay, so that the last evacuated unit has time to walk/drive off the screen/map. I think it's nice polish, might confuse players though (the game says "Mission Accomplished/Failed", but the Game Over screen pops up later; this might look very weird, so it's up to you (and @obrakmann) if we want to take this).
