### PR TITLE
Finish empty video fix for the VQA branch

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
@@ -343,15 +343,28 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				playingVideo = pv;
 				player.Load(video);
 
-				// video playback runs asynchronously
-				player.PlayThen(() =>
+				if (player.Video == null)
 				{
 					StopVideo(player);
-					onComplete?.Invoke();
-				});
 
-				// Mute other distracting sounds
-				MuteSounds();
+					ConfirmationDialogs.ButtonPrompt(
+						title: "Video couldn't play",
+						text: "Something went wrong with the video playback.",
+						cancelText: "Back",
+						onCancel: () => { });
+				}
+				else
+				{
+					// video playback runs asynchronously
+					player.PlayThen(() =>
+					{
+						StopVideo(player);
+						onComplete?.Invoke();
+					});
+
+					// Mute other distracting sounds
+					MuteSounds();
+				}
 			}
 		}
 

--- a/OpenRA.Mods.Common/Widgets/VideoPlayerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/VideoPlayerWidget.cs
@@ -55,10 +55,10 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public void Open(IVideo video)
 		{
+			this.video = video;
+
 			if (video == null)
 				return;
-
-			this.video = video;
 
 			stopped = true;
 			paused = true;


### PR DESCRIPTION
This fixes a bug in `VideoPlayerWidget` where the wrong file might play when you try to play an empty one and also adds a dialog when trying to play an empty file, informing the user *and* the engine that it can't be played.

For https://github.com/OpenRA/OpenRA/pull/20006